### PR TITLE
Add support for Laravel 13 and PHP 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,17 +16,17 @@
     ],
     "require": {
         "doctrine/dbal": "^3.5 | ^4.0 | ^5.0",
-        "illuminate/database": "^10.0|^11.0|^12.0",
-        "illuminate/events": "^10.0|^11.0|^12.0",
-        "illuminate/mail": "^10.0|^11.0|^12.0",
-        "illuminate/routing": "^10.0|^11.0|^12.0",
-        "illuminate/support": "^10.0|^11.0|^12.0",
-        "illuminate/view": "^10.0|^11.0|^12.0",
+        "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/events": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/mail": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/routing": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/view": "^10.0|^11.0|^12.0|^13.0",
         "nesbot/carbon": ">=2.62.1",
         "opcodesio/mail-parser": "^0.2.1"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
         "pestphp/pest": "^3.8"
     },
     "autoload": {


### PR DESCRIPTION
## Summary
- Add Laravel 13 (`^13.0`) support across all `illuminate/*` dependencies in `composer.json`
- Add `orchestra/testbench` `^11.0` for Laravel 13 test compatibility
- Add PHP 8.5 to the CI test matrix in GitHub Actions

## Test plan
- [ ] Verify CI passes for existing PHP/Laravel combinations
- [ ] Verify CI runs for the new PHP 8.5 matrix entries
- [ ] Confirm `composer install` resolves correctly with Laravel 13 packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)