### PR TITLE
Fix config/route bugs and add mail_logs indexes

### DIFF
--- a/config/mail-viewer.php
+++ b/config/mail-viewer.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 return [
     'table' => 'mail_logs',
+    'connection' => env('MAIL_VIEWER_CONNECTION'),
     'middleware' => ['web'],
     'uri_prefix' => env('MAIL_VIEWER_URI_PREFIX', '_mail-viewer'),
     'date_format' => env('MAIL_VIEWER_DATE_FORMAT', 'd.m.Y'),
-    'time_format' => env('MAIL_VIEWER_DATE_FORMAT', 'H:i:s'),
+    'time_format' => env('MAIL_VIEWER_TIME_FORMAT', 'H:i:s'),
     'timezone' => env('MAIL_VIEWER_TIMEZONE', env('APP_TIMEZONE', 'UTC')),
     'emails_per_page' => env('MAIL_VIEWER_EMAILS_PER_PAGE', 20),
     'prune_older_than_days' => env('MAIL_VIEWER_PRUNE_OLDER_THAN_DAYS', 0),

--- a/database/migrations/2026_04_16_120000_add_indexes_to_mail_logs.php
+++ b/database/migrations/2026_04_16_120000_add_indexes_to_mail_logs.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table((string) config('mail-viewer.table', 'mail_logs'), function (Blueprint $table) {
+            $table->index('date');
+            $table->index('subject');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table((string) config('mail-viewer.table', 'mail_logs'), function (Blueprint $table) {
+            $table->dropIndex(['date']);
+            $table->dropIndex(['subject']);
+        });
+    }
+};

--- a/resources/routes/web.php
+++ b/resources/routes/web.php
@@ -26,7 +26,7 @@ Route::group([
         ->name('rawPayload');
 
     Route::get('/emails/{mailLog}/attachments', [MailController::class, 'attachments'])
-        ->name('payload');
+        ->name('attachments');
 
     Route::get('/emails/{mailLog}/attachments/{fileName}', [MailController::class, 'downloadAttachment'])
         ->name('downloadAttachment');

--- a/src/Models/MailLog.php
+++ b/src/Models/MailLog.php
@@ -56,9 +56,11 @@ class MailLog extends Model
 
     public function scopeSearch(Builder $query, string $term): Builder
     {
+        $escaped = addcslashes($term, '%_\\');
+
         return $query
-            ->where('subject', 'like', "%$term%")
-            ->orWhere('headers', 'like', "%$term%");
+            ->where('subject', 'like', "%{$escaped}%")
+            ->orWhere('headers', 'like', "%{$escaped}%");
     }
 
     public function getFormattedDateAttribute(): string


### PR DESCRIPTION
- Fix time_format env var (was reading MAIL_VIEWER_DATE_FORMAT)
- Expose MAIL_VIEWER_CONNECTION config key so the model no longer relies
  on an undocumented fallback
- Rename the attachments route (was duplicated as mail-viewer::payload)
- Escape LIKE wildcards in MailLog::scopeSearch so user input can't
  expand searches via % / _
- Index date and subject on the mail_logs table to speed up stats,
  pruning, date filtering, and search